### PR TITLE
Add tooling for releases

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,34 @@
+---
+- name: C-bug
+  color: e74c3c
+  description: "Report a new bug"
+- name: C-dependency
+  color: e74c3c
+  description: "Change or update a dependency"
+- name: C-documentation
+  color: e74c3c
+  description: "Improve the documentation"
+- name: C-feature-request
+  color: e74c3c
+  description: "Request a new feature"
+- name: R-added
+  color: 95a5a6
+  description: "Add a new feature to the release notes"
+- name: R-changed
+  color: 95a5a6
+  description: "Add a change in existing functionality to the release notes"
+- name: R-deprecated
+  color: 95a5a6
+  description: "Add a soon-to-be removed feature to the release notes"
+- name: R-fixed
+  color: 95a5a6
+  description: "Add a fixed bug to the release notes"
+- name: R-ignore
+  color: 95a5a6
+  description: "Do not add this pull request to the release notes"
+- name: R-removed
+  color: 95a5a6
+  description: "Add a now removed feature to the release notes"
+- name: R-security
+  color: 95a5a6
+  description: "Add a vulnerability warning to the release notes"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+---
+changelog:
+  exclude:
+    labels:
+      - R-ignore
+  categories:
+    - title: Security
+      labels:
+        - R-security
+    - title: Added
+      labels:
+        - R-added
+    - title: Changed
+      labels:
+        - R-changed
+    - title: Deprecated
+      labels:
+        - R-deprecated
+    - title: Removed
+      labels:
+        - R-removed
+    - title: Fixed
+      labels:
+        - R-fixed

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,0 +1,24 @@
+---
+name: GitHub
+
+"on":
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  labels:
+    name: Sync labels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml


### PR DESCRIPTION
Releases will be done using GitHub's native releases feature, which creates a tag on the default branch and a release with an auto-generated changelog. Labels have been added that will be used to add items to the changelog, using the categories from <https://keepachangelog.com>.