### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains an action for use with GitHub Actions, which installs
 The package is installed into `/home/runner/.earthly` (or equivalent on Windows)
 and the `bin` subdirectory is added to the PATH.
 
+This is a fork of the now unmaintained [earthly/actions-setup] action.
+
 ## Usage
 
 Full example:
@@ -24,7 +26,7 @@ jobs:
     name: example earthly test
     runs-on: ubuntu-latest
     steps:
-      - uses: earthly/actions-setup@v1
+      - uses: jdno/earthly-actions-setup@v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest" # or pin to an specific version, e.g. "0.8.1"
@@ -41,7 +43,7 @@ Install the latest version of earthly:
 
 ```yaml
 - name: Install earthly
-  uses: earthly/actions-setup@v1
+  uses: jdno/earthly-actions-setup@v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -50,7 +52,7 @@ Install a specific version of earthly:
 
 ```yaml
 - name: Install earthly
-  uses: earthly/actions-setup@v1
+  uses: jdno/earthly-actions-setup@v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     version: 0.8.1
@@ -60,7 +62,7 @@ Install a version that adheres to a semver range
 
 ```yaml
 - name: Install earthly
-  uses: earthly/actions-setup@v1
+  uses: jdno/earthly-actions-setup@v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     version: ^0.8.0
@@ -68,10 +70,7 @@ Install a version that adheres to a semver range
 
 ### Testing
 
-You can perform a local test by running `earthly +all`.
-
-It is also possible to use [act](https://github.com/nektos/act) to test the
-contents of the github actions config.
+You can perform a local test by running `earthly +checks`.
 
 ## Configuration
 
@@ -86,6 +85,8 @@ The action can be configured with the following arguments:
 
 ## Acknowledgements
 
-This repository was forked from [earthly/actions-setup](https://github.com/earthly/actions-setup)
-after Earthly [deprecated the Earthly project](https://earthly.dev/blog/shutting-down-earthfiles-cloud/).
+This repository was forked from [earthly/actions-setup] after Earthly
+[deprecated the Earthly project](https://earthly.dev/blog/shutting-down-earthfiles-cloud/).
 Big thanks to them for building Earthly!
+
+[earthly/actions-setup]: https://github.com/earthly/actions-setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-earthly",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-earthly",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@actions/cache": "^4.0.0",
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-earthly",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "Setup the earthly in a GitHub Actions build environment",
   "main": "dist/index.js",


### PR DESCRIPTION
The first release in this fork updates all dependencies of the action to their latest version and fixes two issues:

  - The action previously tried to connect to deprecated and now shutdown cache servers, causing a ~9 minute delay in its execution. By updating to the latest version of the `@actions/cache` package, this problem has been resolved.
  - The `use-cache: false` setting was only respected when saving the cache, but not when restoring from an already populated cache at the beginning of each run.